### PR TITLE
Add support for proxy when using Slackiq

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,27 @@ First, set up any number of Slack Incoming Webhooks [from your Slack](https://sl
 Then, you only need to call the `configure` method when your application launches to configure all of the webhooks to which you want to post. If you're using Rails, create an initializer at `config/initializers/slackiq.rb`. Here's an example:
 
 ```ruby
-Slackiq.configure( web_scrapes: 'https://hooks.slack.com/services/HA298HF2/ALSKF2451/lknsaHHA2323KKDKND', 
-                   data_processing: 'https://hooks.slack.com/services/HA298HF2/ALSKF2451/H24dLKAHD22423')
+Slackiq.configure( {web_scrapes: 'https://hooks.slack.com/services/HA298HF2/ALSKF2451/lknsaHHA2323KKDKND', 
+                   data_processing: 'https://hooks.slack.com/services/HA298HF2/ALSKF2451/H24dLKAHD22423'})
 ```
 
 `:web_scrapes` and `data_processing` are examples of keys. Use whatever keys you want.
+
+If you need to use a proxy, `configure` takes a second hash as a parameter to set the proxy settings:
+
+```ruby
+Slackiq.configure( {
+    web_scrapes: 'https://hooks.slack.com/services/HA298HF2/ALSKF2451/lknsaHHA2323KKDKND', 
+    data_processing: 'https://hooks.slack.com/services/HA298HF2/ALSKF2451/H24dLKAHD22423'
+  },
+  {
+    url: 'your-proxy.company.com',
+    port: 8080,
+    username: 'yourname',
+    password: 'password'
+  }
+)
+```
 
 ## Usage
 

--- a/lib/slackiq.rb
+++ b/lib/slackiq.rb
@@ -11,12 +11,12 @@ require 'active_support' #for Hash#except
 module Slackiq
   
   class << self
-    
     # Configure all of the webhook URLs you're going to use
     # @author Jason Lew
-    def configure(webhook_urls={})
-      raise 'Argument must be a Hash' unless webhook_urls.class == Hash
+    def configure(webhook_urls={}, proxy_opts={})
+      raise 'Arguments must be a Hash' unless webhook_urls.class == Hash && proxy_opts.class == Hash
       @@webhook_urls = webhook_urls
+      @@proxy_opts = proxy_opts
     end
     
     # Send a notification to Slack with Sidekiq info about the batch
@@ -131,8 +131,13 @@ module Slackiq
     ]
     
       body = {attachments: attachments}.to_json
-      
-      HTTParty.post(url, body: body)
+
+      HTTParty.post(url, body: body,
+                    http_proxyaddr: @@proxy_opts[:url],
+                    http_proxyport: @@proxy_opts[:port],
+                    http_proxyuser: @@proxy_opts[:user],
+                    http_proxypass: @@proxy_opts[:password]
+      )
     end
 
     # Send a notification without Sidekiq batch info
@@ -141,8 +146,13 @@ module Slackiq
       url = @@webhook_urls[options[:webhook_name]]
 
       body = { 'text' => text }.to_json
-      
-      HTTParty.post(url, body: body)
+
+      HTTParty.post(url, body: body,
+                    http_proxyaddr: @@proxy_opts[:url],
+                    http_proxyport: @@proxy_opts[:port],
+                    http_proxyuser: @@proxy_opts[:user],
+                    http_proxypass: @@proxy_opts[:password]
+      )
     end
     
   end


### PR DESCRIPTION
My team needed to use Slackiq behind a firewall, so I added the ability to pass proxy settings as a hash to `configure`. I just made sure to leverage HTTParty's documentation on proxies and passed the proxy settings along. 

I had to modify how `configure` was originally configured. If you pass in a second hash as a second parameter, the first param needs to be encapsulated in `{ }`. I updated the README to reflect that change. I am open to suggestions if you have a better way of doing that, I realize it will be a change that anyone who upgrades will need to make. 